### PR TITLE
virtcontainers: vhost-user-blk/scsi are block device nodes

### DIFF
--- a/virtcontainers/device/manager/utils.go
+++ b/virtcontainers/device/manager/utils.go
@@ -139,10 +139,10 @@ func isLargeBarSpace(resourcePath string) (bool, error) {
 
 // isVhostUserBlk checks if the device is a VhostUserBlk device.
 func isVhostUserBlk(devInfo config.DeviceInfo) bool {
-	return devInfo.Major == config.VhostUserBlkMajor
+	return devInfo.DevType == "b" && devInfo.Major == config.VhostUserBlkMajor
 }
 
 // isVhostUserSCSI checks if the device is a VhostUserSCSI device.
 func isVhostUserSCSI(devInfo config.DeviceInfo) bool {
-	return devInfo.Major == config.VhostUserSCSIMajor
+	return devInfo.DevType == "b" && devInfo.Major == config.VhostUserSCSIMajor
 }


### PR DESCRIPTION
When checking if a device is an emulated vhost-user-blk or
vhost-user-scsi one, we should not only check for their major number but
also their device node type. They must be block devices.

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>